### PR TITLE
chore: remove global risk tab rebuild listener

### DIFF
--- a/main.js
+++ b/main.js
@@ -2067,13 +2067,7 @@ async function pnlPostLog({ user, amount, note }){
     }
   }, true);
 
-  // 4) Also rebuild when a pinned Risk tab is clicked (ensures bar stays in sync)
-  document.addEventListener('click', (e)=>{
-    const rtab = e.target && e.target.closest('#riskTabBar .rtab');
-    if (rtab) setTimeout(rebuild, 0);
-  }, true);
-
-  // 5) First load safety net
+  // 4) First load safety net
   window.addEventListener('load', ()=>{
     setTimeout(rebuild, 700);
   });


### PR DESCRIPTION
## Summary
- drop document-level listener that rebuilt risk tabs on any pinned tab click
- ensure tabs rebuild only via quick-tab interactions or explicit buttons

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83446976c832890223172b72c2dac