### PR TITLE
feat: cache market hours chip lookup

### DIFF
--- a/main.js
+++ b/main.js
@@ -1927,17 +1927,26 @@ document.addEventListener('click', (ev)=>{
     const closed = ((hh>15 || (hh===15 && mm>=10)) && hh<17);
     return !closed;
   }
+  let marketHoursChipEl = null;
   function findMarketHoursChip(){
+    if(marketHoursChipEl && marketHoursChipEl.isConnected) return marketHoursChipEl;
     // Prefer explicit ids if present
-    let el = document.getElementById('marketHours') || document.getElementById('marketHoursChip');
-    if(el) return el;
-    // Fallback: look for a visible "Market hours" chip only (avoid touching other buttons)
-    const candidates = document.querySelectorAll('.chip, .pill, [class*="chip"], [class*="pill"]');
-    for(const c of candidates){
-      const txt = (c.textContent||'').trim().toLowerCase();
-      if(txt === 'market hours' || txt.indexOf('market hours') !== -1) return c;
+    let el = document.getElementById('marketHours') ||
+             document.getElementById('marketHoursChip') ||
+             document.getElementById('mktStatus');
+    if(!el){
+      // Fallback: look for a visible "Market hours" chip only (avoid touching other buttons)
+      const candidates = document.querySelectorAll('.chip, .pill, [class*="chip"], [class*="pill"]');
+      for(const c of candidates){
+        const txt = (c.textContent||'').trim().toLowerCase();
+        if(txt === 'market hours' || txt.indexOf('market hours') !== -1){
+          el = c;
+          break;
+        }
+      }
     }
-    return null;
+    marketHoursChipEl = el || null;
+    return marketHoursChipEl;
   }
   function update(){
     const chip = findMarketHoursChip();


### PR DESCRIPTION
## Summary
- Cache Market Hours chip element lookup to avoid repeated DOM searches
- Include `mktStatus` ID when finding the market hours chip

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b83de7efc483288c540f3199c0bbb9