### PR TITLE
Fix risk summary error handling string

### DIFF
--- a/main.js
+++ b/main.js
@@ -963,10 +963,14 @@ function leanWindowSmart(bars, minutesDesired){
         const sessionBars=filterToSession(all.bars, all.regStart, all.regEnd);
         const win=selectWindow(sessionBars,trendMinutes);
         const info=statsTrend(win);
-        if(!info.ok){riskSummaryEl.innerHTML=`<span class="muted">Risk read unavailable (${info.reason}
-        // Busy notification tracker
-        try{ busyTrackerTick(info.busyLabel==='Busy'); }catch(_){}
-)</span>`;drawTrend(riskCanvas,[]);return}
+        if(!info.ok){
+          riskSummaryEl.innerHTML =
+            `<span class="muted">Risk read unavailable (${info.reason})</span>`;
+          // Busy notification tracker
+          try { busyTrackerTick(info.busyLabel === 'Busy'); } catch (_) {}
+          drawTrend(riskCanvas, []);
+          return;
+        }
 
         const dirPill=`<span class="pill ${info.dirClass}"><i class="fa-solid fa-arrow-trend-${info.direction==='Downtrend'?'down':'up'}"></i> ${info.direction}</span>`;
         const busyPill=`<span class="pill ${info.busyClass}"><i class="fa-solid fa-bolt"></i> ${info.busyLabel}</span>`;


### PR DESCRIPTION
## Summary
- Close risk read error message template string
- Move busy tracker invocation outside of template string

## Testing
- `node test/isTopstepOpen.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b844996fb88328947a119812a7cd8f